### PR TITLE
Fixed postags that contained too many characters

### DIFF
--- a/public/xml/herodotus-1-40-59.xml
+++ b/public/xml/herodotus-1-40-59.xml
@@ -1718,7 +1718,7 @@
       <word id="16" form="ἐπὶ" lemma="ἐπί" postag="r--------" relation="AuxP" head="20"/>
       <word id="17" form="μὲν" lemma="μέν" postag="d--------" relation="AuxY" head="30"/>
       <word id="18" form="τὰ" lemma="ὁ" postag="l-p---na-" relation="ATR" head="19"/>
-      <word id="19" form="μακρότερα" lemma="μακρός" postag="a-p---nac-----" relation="ADV"
+      <word id="19" form="μακρότερα" lemma="μακρός" postag="a-p---nac" relation="ADV"
             head="16"/>
       <word id="20" form="ποιέων" lemma="ποιέω" postag="v-sppamn-" relation="ADV_CO"
             head="30"/>
@@ -3351,7 +3351,7 @@
             head="16"/>
       <word id="15" form="μεγάλως" lemma="μέγας" postag="d--------" relation="ADV"
             head="14"/>
-      <word id="16" form="αὐξηθῆναι" lemma="αὐξάνω" postag="v--anp--------" relation="OBJ"
+      <word id="16" form="αὐξηθῆναι" lemma="αὐξάνω" postag="v--anp---" relation="OBJ"
             head="5"/>
       <word id="17" form="." lemma="punc1" postag="u--------" relation="AuxK" head="0"/>
    </sentence>

--- a/public/xml/herodotus-1-60-79.xml
+++ b/public/xml/herodotus-1-60-79.xml
@@ -151,7 +151,7 @@
             head="13"/>
       <word id="16" form="πρῆγμα" lemma="πρᾶγμα" postag="n-s---na-" relation="OBJ"
             head="11"/>
-      <word id="17" form="εὐηθέστατον" lemma="εὐήθης" postag="a-s---nas-----"
+      <word id="17" form="εὐηθέστατον" lemma="εὐήθης" postag="a-s---nas"
             relation="ATR"
             head="16"/>
       <word id="18" form="," lemma="punc1" postag="u--------" relation="AuxX" head="19"/>
@@ -178,7 +178,7 @@
             head="27"/>
       <word id="35" form="ἐὸν" lemma="εἰμί" postag="v-sppann-" relation="ATR" head="34"/>
       <word id="36" form="καὶ" lemma="καί" postag="d--------" relation="AuxY" head="38"/>
-      <word id="37" form="δεξιώτερον" lemma="δεξιός" postag="a-s---fnc-----"
+      <word id="37" form="δεξιώτερον" lemma="δεξιός" postag="a-s---fnc"
             relation="PNOM_CO"
             head="38"/>
       <word id="38" form="καὶ" lemma="καί" postag="c--------" relation="COORD" head="35"/>
@@ -271,10 +271,10 @@
       <word id="13" form="οἷόν" lemma="οἷος" postag="a-s---na-" relation="OBJ" head="18"/>
       <word id="14" form="τι" lemma="τις" postag="a-s---na-" relation="ATR" head="13"/>
       <word id="15" form="ἔμελλε" lemma="μέλλω" postag="v3siia---" relation="ATR" head="12"/>
-      <word id="16" form="εὐπρεπέστατον" lemma="εὐπρεπής" postag="a-s---nas-----"
+      <word id="16" form="εὐπρεπέστατον" lemma="εὐπρεπής" postag="a-s---nas"
             relation="PNOM"
             head="17"/>
-      <word id="17" form="φανέεσθαι" lemma="φαίνω" postag="v--fne--------" relation="OBJ"
+      <word id="17" form="φανέεσθαι" lemma="φαίνω" postag="v--fne---" relation="OBJ"
             head="15"/>
       <word id="18" form="ἔχουσα" lemma="ἔχω" postag="v-sppafn-" relation="ADV" head="15"/>
       <word id="19" form="," lemma="punc1" postag="u--------" relation="AuxX" head="10"/>
@@ -318,7 +318,7 @@
       <word id="2" form="Ἀθηναῖοι" lemma="Ἀθηναῖος" postag="n-p---mn-" relation="ExD"
             head="4"/>
       <word id="3" form="," lemma="punc1" postag="u--------" relation="AuxX" head="2"/>
-      <word id="4" form="δέκεσθε" lemma="δέχομαι" postag="v2ppme--------" relation="PRED"
+      <word id="4" form="δέκεσθε" lemma="δέχομαι" postag="v2ppme---" relation="PRED"
             head="0"/>
       <word id="5" form="ἀγαθῷ" lemma="ἀγαθός" postag="a-s---md-" relation="ATR" head="6"/>
       <word id="6" form="νόῳ" lemma="νόος" postag="n-s---md-" relation="ADV" head="4"/>
@@ -1048,7 +1048,7 @@
             relation="SBJ"
             head="29"/>
       <word id="19" form="αὐτῶν" lemma="αὐτός" postag="p-p---mg-" relation="ATR" head="18"/>
-      <word id="20" form="οἳ" lemma="ὁ" postag="l-p---m-------" relation="ATR" head="18"/>
+      <word id="20" form="οἳ" lemma="ὁ" postag="l-p---m--" relation="ATR" head="18"/>
       <word id="21" form="μὲν" lemma="μέν" postag="d--------" relation="AuxY" head="25"/>
       <word id="22" form="πρὸς" lemma="πρός" postag="r--------" relation="AuxP" head="29"/>
       <word id="23" form="κύβους" lemma="κύβος" postag="n-p---ma-" relation="OBJ" head="22"/>
@@ -1747,7 +1747,7 @@
             head="33"/>
       <word id="30" form="Ἀρκάδων" lemma="Ἀρκάς" postag="n-p---mg-" relation="ADV"
             head="31"/>
-      <word id="31" form="κρέσσονες" lemma="κρείσσων" postag="a-p---mnc-----"
+      <word id="31" form="κρέσσονες" lemma="κρείσσων" postag="a-p---mnc"
             relation="PNOM"
             head="32"/>
       <word id="32" form="εἶναι" lemma="εἰμί" postag="v--pna---" relation="OBJ" head="29"/>
@@ -4753,7 +4753,7 @@
       <word id="21" form="χώρης" lemma="χώρη" postag="n-s---fg-" relation="ATR" head="24"/>
       <word id="22" form="ταύτης" lemma="οὗτος" postag="a-s---fg-" relation="ATR" head="21"/>
       <word id="23" form="τὸ" lemma="ὁ" postag="l-s---nn-" relation="ATR" head="24"/>
-      <word id="24" form="ἰσχυρότατον" lemma="ἰσχυρός" postag="a-s---nns-----"
+      <word id="24" form="ἰσχυρότατον" lemma="ἰσχυρός" postag="a-s---nns"
             relation="PNOM"
             head="19"/>
       <word id="25" form="," lemma="punc1" postag="u--------" relation="AuxX" head="35"/>
@@ -4993,7 +4993,7 @@
       <word id="16" form="στρατὸς" lemma="στρατός" postag="n-s---mn-" relation="SBJ"
             head="11"/>
       <word id="17" form="πολλὸν" lemma="πολύς" postag="a-s---na-" relation="ADV" head="18"/>
-      <word id="18" form="ἐλάσσων" lemma="ἐλάσσων" postag="a-s---mnc-----"
+      <word id="18" form="ἐλάσσων" lemma="ἐλάσσων" postag="a-s---mnc"
             relation="PNOM"
             head="11"/>
       <word id="19" form="ἢ" lemma="ἤ1" postag="c--------" relation="AuxC" head="18"/>
@@ -5596,11 +5596,11 @@
       <word id="9" form="τῇ" lemma="ὁ" postag="l-s---fd-" relation="ATR" head="10"/>
       <word id="10" form="Ἀσίῃ" lemma="Ἀσία" postag="n-s---fd-" relation="ATR" head="8"/>
       <word id="11" form="οὔτε" lemma="οὔτε" postag="d--------" relation="AuxY" head="13"/>
-      <word id="12" form="ἀνδρηιότερον" lemma="ἀνδρεῖος" postag="a-s---nnc-----"
+      <word id="12" form="ἀνδρηιότερον" lemma="ἀνδρεῖος" postag="a-s---nnc"
             relation="PNOM_CO"
             head="13"/>
       <word id="13" form="οὔτε" lemma="οὔτε" postag="c--------" relation="COORD" head="1"/>
-      <word id="14" form="ἀλκιμώτερον" lemma="ἄλκιμος" postag="a-s---nnc-----"
+      <word id="14" form="ἀλκιμώτερον" lemma="ἄλκιμος" postag="a-s---nnc"
             relation="PNOM_CO"
             head="13"/>
       <word id="15" form="τοῦ" lemma="ὁ" postag="l-s---mg-" relation="ATR" head="16"/>

--- a/public/xml/herodotus-1-80-99.xml
+++ b/public/xml/herodotus-1-80-99.xml
@@ -665,7 +665,7 @@
             head="21"/>
       <word id="19" form="δ᾽" lemma="δέ" postag="c---------" relation="COORD" head="13"/>
       <word id="20" form="ἂν" lemma="ἄν" postag="d---------" relation="AuxY" head="21"/>
-      <word id="21" form="περιγένωνται" lemma="περιγίγνομαι" postag="v3pasa--------"
+      <word id="21" form="περιγένωνται" lemma="περιγίγνομαι" postag="v3pasa---"
             relation="ATR"
             head="23"/>
       <word id="22" form="," lemma="punc1" postag="u--------" relation="AuxX" head="21"/>
@@ -880,7 +880,7 @@
       <word id="5" form="ἑκάτεροι" lemma="ἑκάτερος" postag="a-p---mn-" relation="ATR"
             head="4"/>
       <word id="6" form="ἔφασαν" lemma="φημί" postag="v3piia---" relation="PRED" head="0"/>
-      <word id="7" form="νικᾶν" lemma="νικάω" postag="v-sppa--------" relation="OBJ"
+      <word id="7" form="νικᾶν" lemma="νικάω" postag="v-sppa---" relation="OBJ"
             head="6"/>
       <word id="8" form="," lemma="punc1" postag="u--------" relation="APOS" head="6"/>
       <word id="9" form="λέγοντες" lemma="λέγω2" postag="v-pppamn-" relation="ATR"
@@ -1004,7 +1004,7 @@
       <word id="33" form="," lemma="punc1" postag="u--------" relation="AuxX" head="32"/>
       <word id="34" form="πρὶν" lemma="πρίν" postag="c---------" relation="AuxC" head="22"/>
       <word id="35" form="Θυρέας" lemma="Θυρέα" postag="n-p---fa-" relation="OBJ" head="36"/>
-      <word id="36" form="ἀνασώσωνται" lemma="ἀνασῴζω" postag="v3pasa--------"
+      <word id="36" form="ἀνασώσωνται" lemma="ἀνασῴζω" postag="v3pasa---"
             relation="ADV"
             head="34"/>
       <word id="37" form="." lemma="punc1" postag="u--------" relation="AuxK" head="0"/>
@@ -1356,7 +1356,7 @@
       <word id="25" form="τὸ" lemma="ὁ" postag="l-s---na-" relation="ATR" head="26"/>
       <word id="26" form="τεῖχος" lemma="τεῖχος" postag="n-s---na-" relation="OBJ"
             head="22"/>
-      <word id="27" form="ἔσονται" lemma="εἰμί" postag="v3pfia--------" relation="OBJ"
+      <word id="27" form="ἔσονται" lemma="εἰμί" postag="v3pfia---" relation="OBJ"
             head="21"/>
       <word id="28" form="Σάρδιες" lemma="Σάρδεις" postag="n-p---fn-" relation="SBJ"
             head="27"/>
@@ -1909,7 +1909,7 @@
       <word id="59" form="μιν" lemma="μιν" postag="p3s---ma-" relation="OBJ" head="61"/>
       <word id="60" form="δαιμόνων" lemma="δαίμων" postag="n-p---mg-" relation="ATR"
             head="58"/>
-      <word id="61" form="ῥύσεται" lemma="ῥύομαι" postag="v3sfia--------" relation="OBJ"
+      <word id="61" form="ῥύσεται" lemma="ῥύομαι" postag="v3sfia---" relation="OBJ"
             head="57"/>
       <word id="62" form="τοῦ" lemma="ὁ" postag="l-s---ng-" relation="ATR" head="65"/>
       <word id="63" form="μὴ" lemma="μή" postag="d---------" relation="AuxZ" head="65"/>
@@ -2249,7 +2249,7 @@
       <word id="25" form="εὐδαιμονίῃ" lemma="εὐδαιμονία" postag="n-s---fd-" relation="ADV"
             head="27"/>
       <word id="26" form="οὐκ" lemma="οὐ" postag="d--------" relation="AuxZ" head="27"/>
-      <word id="27" form="ἐλάσσω" lemma="ἐλάσσων" postag="a-s---mac-----" relation="PNOM"
+      <word id="27" form="ἐλάσσω" lemma="ἐλάσσων" postag="a-s---mac" relation="PNOM"
             head="23"/>
       <word id="28" form="," lemma="punc1" postag="u--------" relation="AuxX" head="23"/>
       <word id="29" form="ζῶντα" lemma="ζάω" postag="v-sppama-" relation="ATV" head="21"/>
@@ -3001,7 +3001,7 @@
       <word id="20" form="ἀναγκαίως" lemma="ἀναγκαῖος" postag="d---------" relation="ADV"
             head="21"/>
       <word id="21" form="ἔχει" lemma="ἔχω" postag="v3spia---" relation="OBJ" head="18"/>
-      <word id="22" form="δεκατευθῆναι" lemma="δεκατεύω" postag="v--anp--------"
+      <word id="22" form="δεκατευθῆναι" lemma="δεκατεύω" postag="v--anp---"
             relation="SBJ"
             head="21"/>
       <word id="23" form="τῷ" lemma="ὁ" postag="l-s---md-" relation="ATR" head="24"/>
@@ -4046,7 +4046,7 @@
             head="27"/>
       <word id="25" form="ἐξ" lemma="ἐκ" postag="r--------" relation="AuxP" head="27"/>
       <word id="26" form="ἀνδρὸς" lemma="ἀνήρ" postag="n-s---mg-" relation="ATR" head="28"/>
-      <word id="27" form="ἐγένετο" lemma="γίγνομαι" postag="v3saia--------"
+      <word id="27" form="ἐγένετο" lemma="γίγνομαι" postag="v3saia---"
             relation="PRED_CO"
             head="22"/>
       <word id="28" form="οὐσίης" lemma="οὐσία" postag="n-s---fg-" relation="PNOM"
@@ -4455,7 +4455,7 @@
    <sentence id="140" document_id="urn:cts:greekLit:tlg0016.tlg001.perseus-grc1"
              subdoc="1.93.5"
              span="">
-      <word id="1" form="καλέεται" lemma="καλέω" postag="v3spia--------" relation="PRED"
+      <word id="1" form="καλέεται" lemma="καλέω" postag="v3spia---" relation="PRED"
             head="0"/>
       <word id="2" form="δὲ" lemma="δέ" postag="d--------" relation="AuxY" head="1"/>
       <word id="3" form="αὕτη" lemma="οὗτος" postag="p-s---fn-" relation="SBJ" head="1"/>
@@ -4567,7 +4567,7 @@
       <word id="2" form="δὲ" lemma="δέ" postag="d--------" relation="AuxY" head="8"/>
       <word id="3" form="ταύτας" lemma="οὗτος" postag="p-p---fa-" relation="SBJ" head="5"/>
       <word id="4" form="τε" lemma="τε" postag="d--------" relation="AuxY" head="9"/>
-      <word id="5" form="ἐξευρεθῆναι" lemma="ἐξευρίσκω" postag="v--anp--------"
+      <word id="5" form="ἐξευρεθῆναι" lemma="ἐξευρίσκω" postag="v--anp---"
             relation="OBJ_CO"
             head="9"/>
       <word id="6" form="παρὰ" lemma="παρά" postag="r--------" relation="AuxP" head="5"/>
@@ -5715,7 +5715,7 @@
             head="20"/>
       <word id="17" form="τῶν" lemma="ὁ" postag="l-p---ng-" relation="ATR" head="18"/>
       <word id="18" form="ἄλλων" lemma="ἄλλος" postag="p-p---ng-" relation="OBJ" head="20"/>
-      <word id="19" form="ἧσσον" lemma="ἥσσων" postag="a-s---nac-----" relation="ADV"
+      <word id="19" form="ἧσσον" lemma="ἥσσων" postag="a-s---nac" relation="ADV"
             head="20"/>
       <word id="20" form="ἐπιμέλεσθαι" lemma="ἐπιμελέομαι" postag="v--pne---"
             relation="OBJ_CO"


### PR DESCRIPTION
Several postags contained more than 9 characters. It frequently occurs in comparatives & superlatives, but not solely. The extra characters were at the end of the postag and were all hyphens "-". They were erased so that the postags contain 9 characters.