### PR TITLE
Changed a postag of χρεόν to "x-----n--"

### DIFF
--- a/public/xml/herodotus-8-78-83.xml
+++ b/public/xml/herodotus-8-78-83.xml
@@ -199,7 +199,7 @@
              span="">
       <word id="1" form="ἡμέας" lemma="ἐγώ" postag="p1p---ma-" relation="OBJ" gloss="" sg="" head="2"/>
       <word id="2" form="στασιάζειν" lemma="στασιάζω" postag="v--pna---" relation="SBJ" gloss="" sg="" head="4"/>
-      <word id="3" form="χρεόν" lemma="χρεών" postag="v-spp_nn_" relation="PNOM" gloss="" sg="" head="4"/>
+      <word id="3" form="χρεόν" lemma="χρεών" postag="x-----n--" relation="PNOM" gloss="" sg="" head="4"/>
       <word id="4" form="ἐστι" lemma="εἰμί" postag="v3spia---" relation="PRED" gloss="" sg="ind stt" head="0"/>
       <word id="5" form="ἔν" lemma="ἐν" postag="r--------" relation="AuxP" gloss="" sg="" head="10"/>
       <word id="6" form="τε" lemma="τε" postag="d--------" relation="AuxY" sg="" gloss="" head="10"/>


### PR DESCRIPTION
Changed an instance of χρεόν which had an incomplete postag with 2 underscores. It was considered a verb in this instance, but I changed it to "x-----n--" as it had been tagged in some previous cases in Herodotus. It's a word that is difficult to categorize according to the Perseus parts of speech.